### PR TITLE
more documentation on queue_name

### DIFF
--- a/lib/Message/Passing/AMQP/Role/DeclaresQueue.pm
+++ b/lib/Message/Passing/AMQP/Role/DeclaresQueue.pm
@@ -80,6 +80,11 @@ Message::Passing::AMQP::Role::DeclaresQueue - Role for instances which have an A
 
 Defines the queue name, defaults to the name returned by the server.
 
+The server may place restrictions on queue names it generates that
+make them unsuitable in scenarios involving server restarts.
+
+Recommend explicitly defining the queue name in those cases.
+
 =head2 queue_durable
 
 Defines if the queue is durable, defaults to true.


### PR DESCRIPTION
add more detail regarding queue_name usage across server restarts.

discovered in researching https://rt.cpan.org/Public/Bug/Display.html?id=92939